### PR TITLE
Fixed numpy TypeError in functions.py

### DIFF
--- a/music/core/functions.py
+++ b/music/core/functions.py
@@ -272,7 +272,7 @@ S = n.sin(foo)  # one period of a sinusoid with Lt samples
 Q = n.hstack(  ( n.ones(int(Lt/2))*-1, n.ones(int(Lt/2)) )  )
 
 # Triangular
-foo = n.linspace(-1, 1, Lt/2, endpoint=False)
+foo = n.linspace(-1, 1, int(Lt/2), endpoint=False) #Casted Lt/2 as int to avoid TypeError
 Tr = n.hstack(  ( foo, foo[::-1] )   )
 
 # Sawtooth


### PR DESCRIPTION
Issue: 
functions.py import generates TypeError when calling numpy.linspace():

Traceback:
Line 275 in functions.py generates:

        File "~/anaconda3/lib/python3.7/site-packages/music/core/functions.py", line 275, in <module>
            foo = n.linspace(-1, 1, Lt/2, endpoint=False)

        File "<__array_function__ internals>", line 6, in linspace

        File "~/anaconda3/lib/python3.7/site-packages/numpy/core/function_base.py", line 121, in linspace
            .format(type(num)))

    TypeError: object of type <class 'float'> cannot be safely interpreted as an integer.


Fix:
>     Correctly casted variable:
>        Lt
>     as int():
>        (Lt/2) -> int(Lt/2)
>     in expression:
>         from (original):
>             foo = n.linspace(-1, 1, Lt/2, endpoint=False)
>         to:
>             foo = n.linspace(-1, 1, int(Lt/2), endpoint=False)
>     in function:
>         W_ (line 275)
>     in location:
>         music/core/functions.py

Function W_ , Line 275, 
From:
> foo = n.linspace(-1, 1, **Lt/2**, endpoint=False)

To: 
> foo = n.linspace(-1, 1, **int(Lt/2)** , endpoint=False)